### PR TITLE
remove xml decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Go Template CLI (tpl)
 
-Render json, yaml, toml & xml with go templates from the command line.
+Render json, yaml, & toml with go templates from the command line.
 
 The templates are executed with the [text/template](https://pkg.go.dev/text/template) package. This means they come with the additional risks and benefits the text templates provide.
 
@@ -12,7 +12,7 @@ Options:
   -f, --file stringArray      template file path. Can be specified multiple times
   -g, --glob stringArray      template file glob. Can be specified multiple times
   -n, --name string           if specified, execute the template with the given name
-  -d, --decoder string        decoder to use for input data. Supported values: json, yaml, toml, xml (default "json")
+  -d, --decoder string        decoder to use for input data. Supported values: json, yaml, toml (default "json")
       --options stringArray   options to pass to the template engine
       --no-newline            do not print newline at the end of the output
   -h, --help                  show the help text

--- a/cmd/tpl/tpl.go
+++ b/cmd/tpl/tpl.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"encoding/xml"
 	"errors"
 	"fmt"
 	"io"
@@ -151,10 +150,9 @@ type decode func(io.Reader, *any) error
 // a map of decoder functions
 func decoderMap() map[string]decode {
 	return map[string]decode{
+		"json": decodeJson,
 		"yaml": decodeYaml,
 		"toml": decodeToml,
-		"xml":  decodeXml,
-		"json": decodeJson,
 	}
 }
 
@@ -177,20 +175,6 @@ func decodeToml(in io.Reader, out *any) error {
 	dec := toml.NewDecoder(in)
 	_, err := dec.Decode(out)
 	return err
-}
-
-func decodeXml(in io.Reader, out *any) error {
-	dec := xml.NewDecoder(in)
-	for {
-		err := dec.Decode(out)
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			return err
-		}
-	}
-	return nil
 }
 
 func decodeJson(in io.Reader, out *any) error {
@@ -227,7 +211,7 @@ func parseFlags() {
 	flag.StringArrayVarP(&files, "file", "f", []string{}, "template file path. Can be specified multiple times")
 	flag.StringArrayVarP(&globs, "glob", "g", []string{}, "template file glob. Can be specified multiple times")
 	flag.StringVarP(&templateName, "name", "n", "", "if specified, execute the template with the given name")
-	flag.StringVarP(&decoder, "decoder", "d", "json", "decoder to use for input data. Supported values: json, yaml, toml, xml")
+	flag.StringVarP(&decoder, "decoder", "d", "json", "decoder to use for input data. Supported values: json, yaml, toml")
 	flag.StringArrayVar(&options, "options", []string{}, "options to pass to the template engine")
 	flag.BoolVar(&noNewline, "no-newline", false, "do not print newline at the end of the output")
 	flag.BoolVarP(&showHelp, "help", "h", false, "show the help text")


### PR DESCRIPTION
decoding data with the xml package requires a proper struct which is not given because all input data is decoded into interface{}. Hence the decoder is removed.

Signed-off-by: Nico Braun <rainbowstack@gmail.com>