### PR TITLE
Enforce fatal error if an include fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This is a fork of https://github.com/bluebrown/go-template-cli.  It contains the
 
  - Calling `include` on a template name that doesn't exist fails. Previously it silently failed.
  - Default decoder is toml instead of json
+ - Templates missing variables immediately error out
+ - Template --options option removed
 
 ## Synopsis
 
@@ -20,7 +22,6 @@ Options:
   -g, --glob stringArray     template file glob. Can be specified multiple times
   -n, --name string          if specified, execute the template with the given name
   -d, --decoder string       decoder to use for input data. Supported values: json, yaml, toml (default "json")
-      --option stringArray   option to pass to the template engine. Can be specified multiple times
       --no-newline           do not print newline at the end of the output
   -h, --help                 show the help text
       --usage                show the short usage text
@@ -62,18 +63,11 @@ note globs need to quotes to avoid shell expansion.
 
 ## Decoders
 
-By default input data is decoded as json and passed to the template to execute. It is possible to use an alternative decoder. The supported decoders are:
+By default input data is decoded as toml and passed to the template to execute. It is possible to use an alternative decoder. The supported decoders are:
 
 - json
 - yaml
 - toml
-
-While json could technically be decoded using the yaml decoder, this is not done by default for performance reasons.
-
-## Options
-
-The `--options` flag is passed to the template engine. Possible options can be found in the [documentation of the template engine](https://pkg.go.dev/text/template#Template.Option).
-The only option currently known is `missingkey`. Since the input data is decoded into `interface{}`, setting `missingkey=zero` will show `<no value>`, if the key does not exist, which is the same as the default. However, `missingkey=error` has some actual use cases.
 
 ## Functions
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ Render json, yaml, & toml with go templates from the command line.
 
 The templates are executed with the [text/template](https://pkg.go.dev/text/template) package. This means they come with the additional risks and benefits of the text template engine.
 
+## Fork Status ##
+
+This is a fork of https://github.com/bluebrown/go-template-cli.  It contains the following fixes:
+
+ - Calling `include` on a template name that doesn't exist fails. Previously it silently failed.
+ - Default decoder is toml instead of json
+
 ## Synopsis
 
 ```console
@@ -88,7 +95,7 @@ chmod 755 tpl
 If you have go installed, you can use the `go install` command to install the binary.
 
 ```bash
-go install github.com/bluebrown/go-template-cli/cmd/tpl@latest
+go install github.com/mlabbe/go-template-cli/cmd/tpl@latest
 ```
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This is a fork of https://github.com/bluebrown/go-template-cli.  It contains the
  - Default decoder is toml instead of json
  - Templates missing variables immediately error out
  - Template --options option removed
+ - New optional `--output-file` argument writes to a file instead of relying on piping
 
 ## Synopsis
 

--- a/README.md
+++ b/README.md
@@ -71,18 +71,9 @@ By default input data is decoded as toml and passed to the template to execute. 
 
 ## Functions
 
-Next to the builtin functions, [Sprig functions](http://masterminds.github.io/sprig/) and [treasure-map functions](https://github.com/bluebrown/treasure-map) are available.
+Next to the builtin functions, [Sprig functions](http://masterminds.github.io/sprig/) and [treasure-map functions](https://github.com/mlabbe/treasure-map) are available.
 
 ## Installation
-
-### Binary
-
-Download the binary from the [release page](https://github.com/bluebrown/go-template-cli/releases). For example
-
-```bash
-curl -fsSL https://github.com/bluebrown/go-template-cli/releases/latest/download/tpl-linux-amd64 >tpl
-chmod 755 tpl
-```
 
 ### Go
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,16 @@ The templates are executed with the [text/template](https://pkg.go.dev/text/temp
 
 ## Fork Status ##
 
-This is a fork of https://github.com/bluebrown/go-template-cli.  It contains the following fixes:
+This is a fork of https://github.com/bluebrown/go-template-cli.  It contains the following changes:
 
  - Calling `include` on a template name that doesn't exist fails. Previously it silently failed.
  - Default decoder is toml instead of json
  - Templates missing variables immediately error out
  - Template --options option removed
  - New optional `--output-file` argument writes to a file instead of relying on piping
+ - New option `--preserve-preamble` preserves build edge specification in output file header
+ 
+As these changes are use-case driven, the fork is considered permanent.
 
 ## Synopsis
 

--- a/README.md
+++ b/README.md
@@ -14,51 +14,33 @@ This is a fork of https://github.com/bluebrown/go-template-cli.  It contains the
  - Template --options option removed
  - New optional `--output-file` argument writes to a file instead of relying on piping
  - New option `--preserve-preamble` preserves build edge specification in output file header
+ - Remove `--file` option for templates, use positional arguments instead.
+ - Previous positional arguments allowing for templates in command line arguments removed.
  
 As these changes are use-case driven, the fork is considered permanent.
 
-## Synopsis
+Note that the docs and tests may break as these changes have not necessarily updated these components thoroughly.
 
-```console
-Usage: tpl [options] [templates]
-Options:
-  -f, --file stringArray     template file path. Can be specified multiple times
-  -g, --glob stringArray     template file glob. Can be specified multiple times
-  -n, --name string          if specified, execute the template with the given name
-  -d, --decoder string       decoder to use for input data. Supported values: json, yaml, toml (default "json")
-      --no-newline           do not print newline at the end of the output
-  -h, --help                 show the help text
-      --usage                show the short usage text
-  -v, --version              show the version
-```
+## Usage
 
-## Input Data
-
-The input data is read from stdin via pipe or redirection. It is actually not required to provide any input data. If no input data is provided, the template is executed with nil data.
-
-```bash
-# Redirection
-tpl '{{ . }}' < path/to/input.json
-# Pipe
-curl localhost | tpl '{{ . }}'
-# nil data
-tpl '{{ . }}'
-```
-
+    # glob in all of the tpl files.
+    # Note this is single quoted -- this is NOT a shell glob.
+    tpl --glob '*.tpl' < vars.toml
+    
 ## Templates
 
 The default templates name is `_gotpl_default` and positional arguments are parsed into this root template. That means while its possible to specify multiple arguments, they will overwrite each other unless they use the `define` keyword to define a named template that can be referenced later when executing the template. If a named template is parsed multiple times, the last one will override the previous ones.
 
-Templates from the flags `--file` and `--glob` are parsed in the order they are specified. So the override rules of the text/template package apply. If a file with the same name is specified multiple times, the last one wins. Even if they are in different directories.
+Templates from the flag `--glob` are parsed in the order they are specified. So the override rules of the text/template package apply. If a file with the same name is specified multiple times, the last one wins. Even if they are in different directories.
 
 The behavior of the cli tries to stay consistent with the actual behavior of the go template engine.
 
 If the default template exists it will be used unless the `--name` flag is specified. If no default template exists because no positional argument has been provided, the template with the given file name is used, as long as only one file has been parsed. If multiple files have been parsed, the `--name` flag is required to avoid ambiguity.
 
 ```bash
-tpl '{{ . }}' --file foo.tpl --glob 'templates/*.tpl'         # default will be used
-tpl --file foo.tpl                                            # foo.tpl will be used
-tpl --file foo.tpl --glob 'templates/*.tpl' --name foo.tpl    # the --name flag is required to select a template by name
+tpl '{{ . }}' foo.tpl --glob 'templates/*.tpl'         # default will be used
+tpl foo.tpl                                            # foo.tpl will be used
+tpl foo.tpl --glob 'templates/*.tpl' --name foo.tpl    # the --name flag is required to select a template by name
 ```
 
 The ability to parse multiple templates makes sense when defining helper snippets and other named templates to reference using the builtin `template` keyword or the custom `include` function which can be used in pipelines.

--- a/cmd/tpl/cli.go
+++ b/cmd/tpl/cli.go
@@ -44,14 +44,14 @@ func new(fs *pflag.FlagSet) *state {
 
 	cli := &state{
 		flagSet:             fs,
-		decoder:             decodeJson,
+		decoder:             decodeToml,
 		defaultTemplateName: "_gotpl_default",
 	}
 
 	fs.StringArrayVarP(&cli.files, "file", "f", cli.files, "template file path. Can be specified multiple times")
 	fs.StringArrayVarP(&cli.globs, "glob", "g", cli.globs, "template file glob. Can be specified multiple times")
 	fs.StringVarP(&cli.templateName, "name", "n", cli.templateName, "if specified, execute the template with the given name")
-	fs.VarP(&cli.decoder, "decoder", "d", "decoder to use for input data. Supported values: json, yaml, toml (default \"json\")")
+	fs.VarP(&cli.decoder, "decoder", "d", "decoder to use for input data. Supported values: json, yaml, toml (default \"toml\")")
 	fs.StringArrayVar(&cli.options, "option", cli.options, "option to pass to the template engine. Can be specified multiple times")
 	fs.BoolVar(&cli.noNewline, "no-newline", cli.noNewline, "do not print newline at the end of the output")
 	fs.BoolVar(&cli.showVersion, "version", cli.showVersion, "show version information and exit")

--- a/cmd/tpl/cli.go
+++ b/cmd/tpl/cli.go
@@ -16,6 +16,8 @@ import (
 
 var version = "dev"
 
+var FatalMissingInclude = true
+
 // the state of the program
 type state struct {
 	// options
@@ -270,6 +272,6 @@ func (cli *state) selectTemplate() (string, error) {
 func baseTemplate(defaultName string, options ...string) *template.Template {
 	tpl := template.New(defaultName)
 	tpl = tpl.Option(options...)
-	tpl = tpl.Funcs(textfunc.MapClosure(sprig.TxtFuncMap(), tpl))
+	tpl = tpl.Funcs(textfunc.MapClosure(sprig.TxtFuncMap(), tpl, FatalMissingInclude))
 	return tpl
 }

--- a/cmd/tpl/cli.go
+++ b/cmd/tpl/cli.go
@@ -14,7 +14,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var version = "dev"
+var version = "github.com/mlabbe/go-template-cli"
 
 // always strict
 var FatalMissingInclude = true

--- a/cmd/tpl/cli.go
+++ b/cmd/tpl/cli.go
@@ -16,7 +16,9 @@ import (
 
 var version = "dev"
 
+// always strict
 var FatalMissingInclude = true
+var TemplateOptions = "missingkey=error"
 
 // the state of the program
 type state struct {
@@ -25,7 +27,6 @@ type state struct {
 	files               []string
 	globs               []string
 	templateName        string
-	options             []string
 	decoder             decoder
 	noNewline           bool
 	showVersion         bool
@@ -52,7 +53,6 @@ func new(fs *pflag.FlagSet) *state {
 	fs.StringArrayVarP(&cli.globs, "glob", "g", cli.globs, "template file glob. Can be specified multiple times")
 	fs.StringVarP(&cli.templateName, "name", "n", cli.templateName, "if specified, execute the template with the given name")
 	fs.VarP(&cli.decoder, "decoder", "d", "decoder to use for input data. Supported values: json, yaml, toml (default \"toml\")")
-	fs.StringArrayVar(&cli.options, "option", cli.options, "option to pass to the template engine. Can be specified multiple times")
 	fs.BoolVar(&cli.noNewline, "no-newline", cli.noNewline, "do not print newline at the end of the output")
 	fs.BoolVar(&cli.showVersion, "version", cli.showVersion, "show version information and exit")
 
@@ -111,7 +111,7 @@ func (cli *state) parseFlagset(rawArgs []string) error {
 		return err
 	}
 
-	cli.template = baseTemplate(cli.defaultTemplateName, cli.options...)
+	cli.template = baseTemplate(cli.defaultTemplateName)
 
 	return nil
 }
@@ -269,9 +269,10 @@ func (cli *state) selectTemplate() (string, error) {
 }
 
 // construct a base templates with custom functions attached
-func baseTemplate(defaultName string, options ...string) *template.Template {
+func baseTemplate(defaultName string) *template.Template {
+
 	tpl := template.New(defaultName)
-	tpl = tpl.Option(options...)
+	tpl = tpl.Option(TemplateOptions)
 	tpl = tpl.Funcs(textfunc.MapClosure(sprig.TxtFuncMap(), tpl, FatalMissingInclude))
 	return tpl
 }

--- a/cmd/tpl/cli.go
+++ b/cmd/tpl/cli.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/Masterminds/sprig/v3"
-	"github.com/bluebrown/treasure-map/textfunc"
+	"github.com/mlabbe/treasure-map/textfunc"
 	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v3"
 )

--- a/cmd/tpl/preamble.go
+++ b/cmd/tpl/preamble.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// only this number of bytes in the header is scanned for preamble
+// before loading the whole file
+const PreambleBufferSize = 512
+const PreambleSymbol = "-|-"
+const PreambleMagicString = "-|- build-edge:"
+
+func doesContainPreamble(outputPath string) (bool, error) {
+	file, err := os.Open(outputPath)
+	if err != nil {
+		return false, err
+	}
+	defer file.Close()
+
+	buffer := make([]byte, PreambleBufferSize)
+	n, err := file.Read(buffer)
+	if err != nil {
+		return false, err
+	}
+
+	if n == 0 {
+		return false, nil
+	}
+
+	fileHeader := string(buffer)
+	return strings.Contains(fileHeader, PreambleMagicString), nil
+}
+
+func GetPreamble(outputPath string) (string, error) {
+	containsPreamble, err := doesContainPreamble(outputPath)
+	if err != nil {
+		return "", err
+	}
+
+	if !containsPreamble {
+		return "", nil
+	}
+
+	file, err := os.Open(outputPath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+
+	var outBuf string
+
+	// scan until first build edge spec line
+	found := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, PreambleSymbol) {
+			outBuf += line + "\n"
+			found = true
+			break
+		}
+
+		outBuf += line + "\n"
+	}
+
+	if !found {
+		return "", fmt.Errorf("Build spec scan error")
+	}
+
+	// scan until last build edge spec line
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.Contains(line, PreambleSymbol) {
+			break
+		}
+
+		outBuf += line + "\n"
+	}
+
+	return outBuf, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bluebrown/go-template-cli
+module github.com/mlabbe/go-template-cli
 
 go 1.22
 
@@ -22,5 +22,3 @@ require (
 	github.com/spf13/cast v1.6.0 // indirect
 	golang.org/x/crypto v0.22.0 // indirect
 )
-
-//replace github.com/bluebrown/treasure-map => github.com/mlabbe/treasure-map v0.0.0-20240507174921-d12775266909

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22
 require (
 	github.com/BurntSushi/toml v1.3.2
 	github.com/Masterminds/sprig/v3 v3.2.3
-	github.com/bluebrown/treasure-map v0.0.0-20220418173404-da5d8eccbd25
+	github.com/mlabbe/treasure-map v0.0.0-20240507174921-d12775266909
 	github.com/spf13/pflag v1.0.5
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -18,10 +18,9 @@ require (
 	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
-	github.com/mlabbe/treasure-map v0.0.0-20240507064420-75978225e02d // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
 	golang.org/x/crypto v0.22.0 // indirect
 )
 
-replace github.com/bluebrown/treasure-map => github.com/mlabbe/treasure-map v0.0.0-20240507174921-d12775266909
+//replace github.com/bluebrown/treasure-map => github.com/mlabbe/treasure-map v0.0.0-20240507174921-d12775266909

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,10 @@ require (
 	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/mlabbe/treasure-map v0.0.0-20240507064420-75978225e02d // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
 	golang.org/x/crypto v0.22.0 // indirect
 )
+
+replace github.com/bluebrown/treasure-map => github.com/mlabbe/treasure-map v0.0.0-20240507174921-d12775266909

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,6 @@ github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HK
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/mlabbe/treasure-map v0.0.0-20240507064420-75978225e02d h1:8LAvf2LX0PZAoKIopxZeaPZythTqPnmlJmAyUEVsEzg=
-github.com/mlabbe/treasure-map v0.0.0-20240507064420-75978225e02d/go.mod h1:FahYE+KcxAI45blSRgNJXftHJw3CVEvp7+40vXt8TAA=
 github.com/mlabbe/treasure-map v0.0.0-20240507174921-d12775266909 h1:dPlTjq8juRZytDj9JLT694wZ8z9EoqRMW2Dm77OJ7ok=
 github.com/mlabbe/treasure-map v0.0.0-20240507174921-d12775266909/go.mod h1:FahYE+KcxAI45blSRgNJXftHJw3CVEvp7+40vXt8TAA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,6 @@ github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0
 github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/Masterminds/sprig/v3 v3.2.3 h1:eL2fZNezLomi0uOLqjQoN6BfsDD+fyLtgbJMAj9n6YA=
 github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBaRMhvYXJNkGuM=
-github.com/bluebrown/treasure-map v0.0.0-20220418173404-da5d8eccbd25 h1:vDjJLZWCAHKIzzY/27uYpl55KU/+TOh5GFMY+7RCVyE=
-github.com/bluebrown/treasure-map v0.0.0-20220418173404-da5d8eccbd25/go.mod h1:SE+/8VUGK0r8Gf5+rT4jBC35s0JiC3So051vCwIdTCg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -35,6 +33,10 @@ github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HK
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/mlabbe/treasure-map v0.0.0-20240507064420-75978225e02d h1:8LAvf2LX0PZAoKIopxZeaPZythTqPnmlJmAyUEVsEzg=
+github.com/mlabbe/treasure-map v0.0.0-20240507064420-75978225e02d/go.mod h1:FahYE+KcxAI45blSRgNJXftHJw3CVEvp7+40vXt8TAA=
+github.com/mlabbe/treasure-map v0.0.0-20240507174921-d12775266909 h1:dPlTjq8juRZytDj9JLT694wZ8z9EoqRMW2Dm77OJ7ok=
+github.com/mlabbe/treasure-map v0.0.0-20240507174921-d12775266909/go.mod h1:FahYE+KcxAI45blSRgNJXftHJw3CVEvp7+40vXt8TAA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=


### PR DESCRIPTION
This requires pull request on treasure-map to be merged https://github.com/bluebrown/treasure-map/pull/1

This could be made into a cli option, but I would highly recommend fatal error by default.